### PR TITLE
Added ping/echo to lampshade protocol

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -93,17 +93,18 @@ func (d *dialer) DialStream() (Stream, error) {
 	d.id++
 	d.mx.Unlock()
 
-	c, _, _ := current.getOrCreateStream(id)
+	c, _ := current.getOrCreateStream(id)
 	return c, nil
 }
 
 func (d *dialer) EMARTT() time.Duration {
 	var rtt time.Duration
 	d.mx.Lock()
-	if d.current != nil {
-		rtt = d.current.EMARTT()
-	}
+	current := d.current
 	d.mx.Unlock()
+	if current != nil {
+		rtt = current.EMARTT()
+	}
 	return rtt
 }
 

--- a/lampshade.go
+++ b/lampshade.go
@@ -156,6 +156,16 @@
 //       to buffer, the server can adjust the window by sending an ACK with a
 //       negative value
 //
+// Ping Protocol:
+//
+//   Dialers can optionally be configured to use an embedded ping/echo protocol
+//   to maintain an exponential moving average round trip time (RTT). The ping
+//   protocol is similar to an ICMP ping. The client sends a ping packet
+//   containing a 64-bit unsigned integer timestamp and the server responds with
+//   an echo containing that same timestamp. For blocking resistance and
+//   efficiency, pings are only sent with other outgoing frames. If there's no
+//   outgoing traffic, no pings will be sent.
+//
 package lampshade
 
 import (

--- a/lampshade.go
+++ b/lampshade.go
@@ -126,8 +126,8 @@
 //
 //     Data     - data (for type "data" or "padding")
 //
-//     TS       - time at which ping packet was sent as 64-bit uint
-//                (for type "ping" and "echo")
+//     TS       - time at which ping packet was sent as 64-bit uint nanoseconds
+//                since epoch (for type "ping" and "echo")
 //
 // Padding:
 //

--- a/lampshade.go
+++ b/lampshade.go
@@ -126,8 +126,10 @@
 //
 //     Data     - data (for type "data" or "padding")
 //
-//     TS       - time at which ping packet was sent as 64-bit uint nanoseconds
-//                since epoch (for type "ping" and "echo")
+//     TS       - time at which ping packet was sent as 64-bit uint. This is a
+//                passthrough value, so the client implementation can put
+//                whatever it wants in here in order to calculate its RTT.
+//                (for type "ping" and "echo")
 //
 // Padding:
 //

--- a/listener.go
+++ b/listener.go
@@ -104,6 +104,6 @@ func (l *listener) doOnConn(conn net.Conn) error {
 	if err != nil {
 		return fmt.Errorf("Unable to initialize encryption cipher: %v", err)
 	}
-	startSession(conn, windowSize, maxPadding, decrypt, encrypt, nil, l.pool, l.connCh, nil)
+	startSession(conn, windowSize, maxPadding, 0, decrypt, encrypt, nil, l.pool, l.connCh, nil)
 	return nil
 }

--- a/session.go
+++ b/session.go
@@ -22,7 +22,6 @@ type session struct {
 	decrypt       func([]byte)                 // decrypt in place
 	encrypt       func(dst []byte, src []byte) // encrypt to a destination
 	clientInitMsg []byte
-	isClient      bool
 	pool          BufferPool
 	out           chan []byte
 	echoOut       chan []byte
@@ -47,16 +46,16 @@ func startSession(conn net.Conn, windowSize int, maxPadding int, pingInterval ti
 		decrypt:       decrypt,
 		encrypt:       encrypt,
 		clientInitMsg: clientInitMsg,
-		isClient:      clientInitMsg != nil,
 		pool:          pool,
-		out:           make(chan []byte, 1000), // TODO: maybe make this buffer depth smarter
+		out:           make(chan []byte),
 		echoOut:       make(chan []byte, 10),
 		streams:       make(map[uint16]*stream),
 		closed:        make(map[uint16]bool),
 		connCh:        connCh,
 		beforeClose:   beforeClose,
 	}
-	if s.isClient {
+	isClient := clientInitMsg != nil
+	if isClient {
 		s.emaRTT = ema.NewDuration(0, 0.5)
 	}
 	go s.sendLoop(pingInterval)

--- a/stream.go
+++ b/stream.go
@@ -3,10 +3,7 @@ package lampshade
 import (
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
-
-	"github.com/getlantern/mtime"
 )
 
 // a stream is a multiplexed net.Conn operating on top of a physical net.Conn
@@ -22,7 +19,6 @@ type stream struct {
 	closed        bool
 	finalReadErr  error
 	finalWriteErr error
-	firstWrite    uint64
 	mx            sync.RWMutex
 }
 
@@ -46,9 +42,6 @@ func (c *stream) Write(b []byte) (int, error) {
 	closed := c.closed
 	writeDeadline := c.writeDeadline
 	finalWriteErr := c.finalWriteErr
-	if c.firstWrite == 0 {
-		atomic.StoreUint64(&c.firstWrite, uint64(mtime.Now()))
-	}
 	c.mx.RUnlock()
 	if finalWriteErr != nil {
 		return 0, finalWriteErr


### PR DESCRIPTION
@myleshorton @joesis 

This adds a ping/echo protocol to lampshade that supports periodic RTT timing. Ping frames only go out attached to other frames, so on a completely idle connection there is no additional overhead.

The RTT timings will be useful for proxy selection.