### PR TITLE
Proper closing of streams on session error

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -41,6 +41,7 @@ func WrapListener(wrapped net.Listener, pool BufferPool, serverPrivateKey *rsa.P
 		errCh:            make(chan error),
 	}
 	go l.process()
+	trackStats()
 	return l
 }
 

--- a/receive_buffer.go
+++ b/receive_buffer.go
@@ -138,6 +138,13 @@ func (buf *receiveBuffer) ackIfNecessary() {
 }
 
 func (buf *receiveBuffer) sendACK() {
+	buf.mx.RLock()
+	closed := buf.closed
+	buf.mx.RUnlock()
+	if closed {
+		// Don't bother acking
+		return
+	}
 	buf.ack <- ackWithFrames(buf.defaultHeader, int32(buf.unacked))
 }
 


### PR DESCRIPTION
For getlantern/lantern-internal#1294.

With the session stats tracking, I was able to see that our send loops weren't terminating when the session was closed. Now, the send loops terminate.