### PR TITLE
unlock mutex properly in DialStream

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -114,6 +114,7 @@ func (d *dialer) DialStream(dial DialFN) (Stream, error) {
 		var err error
 		current, err = d.startSession(dial)
 		if err != nil {
+			d.mx.Unlock()
 			return nil, err
 		}
 	}
@@ -139,7 +140,6 @@ func (d *dialer) EMARTT() time.Duration {
 func (d *dialer) startSession(dial DialFN) (*session, error) {
 	conn, err := dial()
 	if err != nil {
-		d.mx.Unlock()
 		return nil, err
 	}
 


### PR DESCRIPTION
@oxtoacart please correct me if I'm wrong, but if the code after L146 returns an error (though hardly happen), the mutex will not be unlocked. This properly unlocks the mutex.