### PR TITLE
reduce piled goroutines

### DIFF
--- a/lampshade_test.go
+++ b/lampshade_test.go
@@ -390,6 +390,22 @@ func echoServerAndDialer(maxStreamsPerConn uint16) (net.Listener, Dialer, DialFN
 	}, &wg, nil
 }
 
+func TestCloseStreamAfterSessionClosed(t *testing.T) {
+	l, _, dial, _, err := echoServerAndDialer(0)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer l.Close()
+
+	conn, err := dial()
+	if !assert.NoError(t, err) {
+		return
+	}
+	conn.(Stream).Session().Close()
+	// Simply make sure it doesn't block
+	conn.Close()
+}
+
 func TestConcurrency(t *testing.T) {
 	concurrency := 100
 

--- a/mock_writer_test.go
+++ b/mock_writer_test.go
@@ -1,0 +1,10 @@
+package lampshade
+
+type mockWriter struct {
+	c chan []byte
+}
+
+func (m *mockWriter) Write(b []byte) (int, error) {
+	m.c <- b
+	return len(b), nil
+}

--- a/receive_buffer.go
+++ b/receive_buffer.go
@@ -22,7 +22,7 @@ type receiveBuffer struct {
 	ackInterval   int
 	unacked       int
 	in            chan []byte
-	ack           chan []byte
+	ack           io.Writer
 	pool          BufferPool
 	poolable      []byte
 	current       []byte
@@ -30,7 +30,7 @@ type receiveBuffer struct {
 	mx            sync.RWMutex
 }
 
-func newReceiveBuffer(defaultHeader []byte, ack chan []byte, pool BufferPool, windowSize int) *receiveBuffer {
+func newReceiveBuffer(defaultHeader []byte, ack io.Writer, pool BufferPool, windowSize int) *receiveBuffer {
 	ackInterval := int(math.Ceil(float64(windowSize) / 10))
 	return &receiveBuffer{
 		defaultHeader: defaultHeader,
@@ -145,7 +145,7 @@ func (buf *receiveBuffer) sendACK() {
 		// Don't bother acking
 		return
 	}
-	buf.ack <- ackWithFrames(buf.defaultHeader, int32(buf.unacked))
+	buf.ack.Write(ackWithFrames(buf.defaultHeader, int32(buf.unacked)))
 }
 
 func (buf *receiveBuffer) onFrame(frame []byte) {

--- a/receive_buffer_test.go
+++ b/receive_buffer_test.go
@@ -15,7 +15,7 @@ func TestReceiveBuffer(t *testing.T) {
 	depth := 5
 
 	pool := &testpool{}
-	ack := make(chan []byte, 1000)
+	ack := &mockWriter{make(chan []byte, 1000)}
 	buf := newReceiveBuffer(header, ack, pool, depth)
 	for i := 0; i < 2; i++ {
 		b := pool.Get()
@@ -36,7 +36,7 @@ func TestReceiveBuffer(t *testing.T) {
 ackloop:
 	for {
 		select {
-		case a := <-ack:
+		case a := <-ack.c:
 			if assert.EqualValues(t, frameTypeACK, a[winSize]) {
 				a2 := withFrameType(a[winSize:], frameTypeData)
 				if assert.EqualValues(t, header, a2) {

--- a/sendbuffer.go
+++ b/sendbuffer.go
@@ -99,6 +99,10 @@ func (buf *sendBuffer) sendLoop(out chan []byte) {
 	}
 }
 
+func (buf *sendBuffer) sendUntil(t time.Duration) {
+
+}
+
 func (buf *sendBuffer) close(sendRST bool) {
 	select {
 	case buf.closeRequested <- sendRST:

--- a/sendbuffer.go
+++ b/sendbuffer.go
@@ -111,5 +111,9 @@ func (buf *sendBuffer) close(sendRST bool) {
 
 func (buf *sendBuffer) sendRST(out chan []byte) {
 	// Send an RST frame with the streamID
-	out <- withFrameType(buf.defaultHeader, frameTypeRST)
+	select {
+	case out <- withFrameType(buf.defaultHeader, frameTypeRST):
+	default:
+		log.Trace("can't send RST to peer")
+	}
 }

--- a/sendbuffer_test.go
+++ b/sendbuffer_test.go
@@ -13,7 +13,7 @@ func TestSendBuffer(t *testing.T) {
 
 	depth := 5
 
-	out := make(chan []byte)
+	out := &mockWriter{make(chan []byte)}
 	buf := newSendBuffer(header, out, depth)
 
 	// write loop
@@ -29,7 +29,7 @@ func TestSendBuffer(t *testing.T) {
 loop:
 	for {
 		select {
-		case b := <-out:
+		case b := <-out.c:
 			if assert.EqualValues(t, header, b[1:]) {
 				wrote += string(b[:1])
 			}
@@ -45,7 +45,7 @@ loop:
 loop2:
 	for {
 		select {
-		case b := <-out:
+		case b := <-out.c:
 			if assert.EqualValues(t, header, b[1:]) {
 				wrote += string(b[:1])
 			}

--- a/session.go
+++ b/session.go
@@ -89,7 +89,7 @@ func startSession(conn net.Conn, windowSize int, maxPadding int, pingInterval ti
 		lastPing:         time.Now(),
 		sendSessionFrame: make([]byte, maxSessionFrameSize), // Pre-allocate a sessionFrame for sending
 		sendLengthBuffer: make([]byte, lenSize),             // pre-allocate buffer for length to avoid extra allocations
-		out:              make(chan []byte),
+		out:              make(chan []byte, 1),
 		echoOut:          make(chan []byte),
 		streams:          make(map[uint16]*stream),
 		closed:           make(map[uint16]bool),

--- a/session.go
+++ b/session.go
@@ -459,15 +459,7 @@ func (s *session) getOrCreateStream(id uint16) (*stream, bool) {
 		return nil, false
 	}
 
-	defaultHeader := newHeader(frameTypeData, id)
-	c = &stream{
-		Conn:       s,
-		session:    s,
-		pool:       s.pool,
-		sb:         newSendBuffer(defaultHeader, s.out, s.windowSize),
-		rb:         newReceiveBuffer(defaultHeader, s.out, s.pool, s.windowSize),
-		writeTimer: time.NewTimer(oneYear),
-	}
+	c = newStream(s, s.pool, s.out, s.windowSize, newHeader(frameTypeData, id))
 	s.streams[id] = c
 	s.mx.Unlock()
 	if s.connCh != nil {

--- a/session.go
+++ b/session.go
@@ -179,14 +179,13 @@ func (s *session) recvLoop() {
 					// Stream was already closed, ignore
 					continue
 				}
-				_ackedFrames := b[headerSize:ackFrameSize]
-				_, err = io.ReadFull(r, _ackedFrames)
+				ackedFrames := b[headerSize:ackFrameSize]
+				_, err = io.ReadFull(r, ackedFrames)
 				if err != nil {
 					s.onSessionError(err, nil)
 					return
 				}
-				ackedFrames := int(binaryEncoding.Uint32(_ackedFrames))
-				c.sb.window.add(ackedFrames)
+				c.ack(int(binaryEncoding.Uint32(ackedFrames)))
 				continue
 			case frameTypeRST:
 				// Closing existing connection

--- a/session.go
+++ b/session.go
@@ -89,7 +89,7 @@ func startSession(conn net.Conn, windowSize int, maxPadding int, pingInterval ti
 		lastPing:         time.Now(),
 		sendSessionFrame: make([]byte, maxSessionFrameSize), // Pre-allocate a sessionFrame for sending
 		sendLengthBuffer: make([]byte, lenSize),             // pre-allocate buffer for length to avoid extra allocations
-		out:              make(chan []byte, 1),
+		out:              make(chan []byte),
 		echoOut:          make(chan []byte),
 		streams:          make(map[uint16]*stream),
 		closed:           make(map[uint16]bool),

--- a/stream.go
+++ b/stream.go
@@ -23,6 +23,17 @@ type stream struct {
 	mx            sync.RWMutex
 }
 
+func newStream(s *session, bp BufferPool, out chan []byte, windowSize int, defaultHeader []byte) *stream {
+	return &stream{
+		Conn:       s,
+		session:    s,
+		pool:       bp,
+		sb:         newSendBuffer(defaultHeader, out, windowSize),
+		rb:         newReceiveBuffer(defaultHeader, out, bp, windowSize),
+		writeTimer: time.NewTimer(oneYear),
+	}
+}
+
 func (c *stream) Read(b []byte) (int, error) {
 	c.mx.RLock()
 	readDeadline := c.readDeadline

--- a/stream.go
+++ b/stream.go
@@ -1,6 +1,7 @@
 package lampshade
 
 import (
+	"io"
 	"net"
 	"sync"
 	"time"
@@ -23,13 +24,13 @@ type stream struct {
 	mx            sync.RWMutex
 }
 
-func newStream(s *session, bp BufferPool, out chan []byte, windowSize int, defaultHeader []byte) *stream {
+func newStream(s *session, bp BufferPool, w io.Writer, windowSize int, defaultHeader []byte) *stream {
 	return &stream{
 		Conn:       s,
 		session:    s,
 		pool:       bp,
-		sb:         newSendBuffer(defaultHeader, out, windowSize),
-		rb:         newReceiveBuffer(defaultHeader, out, bp, windowSize),
+		sb:         newSendBuffer(defaultHeader, w, windowSize),
+		rb:         newReceiveBuffer(defaultHeader, w, bp, windowSize),
 		writeTimer: time.NewTimer(oneYear),
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -108,6 +108,10 @@ func (c *stream) writeChunks(b []byte) (int, error) {
 	}
 }
 
+func (c *stream) ack(frames int) {
+	c.sb.window.add(frames)
+}
+
 func (c *stream) Close() error {
 	return c.close(true, ErrConnectionClosed, ErrConnectionClosed)
 }


### PR DESCRIPTION
It's by no means a solution for https://github.com/getlantern/lantern-internal/issues/1462, but the piled up goroutines disappear with this code.