### PR TITLE
Use channel to keep track of live sessions

### DIFF
--- a/lampshade.go
+++ b/lampshade.go
@@ -201,6 +201,7 @@
 package lampshade
 
 import (
+	"context"
 	"encoding/binary"
 	"net"
 	"time"
@@ -306,9 +307,8 @@ type Dialer interface {
 	// DialFN to open a physical connection when necessary.
 	Dial(dial DialFN) (net.Conn, error)
 
-	// DialStream is the same as Dial but returns the internal interface for
-	// virtual connections.
-	DialStream(dial DialFN) (Stream, error)
+	// DialContext is the same as Dial but with the specific context.
+	DialContext(ctx context.Context, dial DialFN) (net.Conn, error)
 
 	// BoundTo returns a BoundDialer that uses the given DialFN to connect to the
 	// lampshade server.
@@ -323,9 +323,8 @@ type BoundDialer interface {
 	// Dial creates a virtual connection to the lampshade server.
 	Dial() (net.Conn, error)
 
-	// DialStream is the same as Dial() but returns the internal interface for
-	// virtual connectinos.
-	DialStream() (Stream, error)
+	// DialContext is the same as Dial but with the specific context.
+	DialContext(ctx context.Context) (net.Conn, error)
 }
 
 // Session is a wrapper around a net.Conn that supports multiplexing.

--- a/lampshade.go
+++ b/lampshade.go
@@ -330,7 +330,6 @@ type BoundDialer interface {
 // Session is a wrapper around a net.Conn that supports multiplexing.
 type Session interface {
 	net.Conn
-	StatsTracking
 
 	// Wrapped() exposes access to the net.Conn that's wrapped by this Session.
 	Wrapped() net.Conn

--- a/listener.go
+++ b/listener.go
@@ -131,6 +131,6 @@ func (l *listener) doOnConn(conn net.Conn) error {
 		l.onError(conn, fullErr)
 		return fullErr
 	}
-	startSession(conn, windowSize, maxPadding, 0, cs.reversed(), nil, l.pool, l.connCh, nil)
+	startSession(conn, windowSize, maxPadding, 0, cs.reversed(), nil, l.pool, nil, l.connCh, nil)
 	return nil
 }

--- a/session.go
+++ b/session.go
@@ -552,8 +552,7 @@ func (s *session) getOrCreateStream(id uint16) (*stream, bool) {
 
 // AllowNewStream returns true if a new stream is allowed to be created over
 // this session, and false otherwise.
-func (s *session) AllowNewStream(maxStreamPerConn uint16, idleInterval
-time.Duration) bool {
+func (s *session) AllowNewStream(maxStreamPerConn uint16, idleInterval time.Duration) bool {
 	nextID := atomic.LoadUint32(&s.nextID)
 	if nextID > uint32(maxStreamPerConn) {
 		log.Debug("Exhausted maximum allowed IDs on one physical connection, will open new connection")


### PR DESCRIPTION
It's an alternative way for https://github.com/getlantern/lantern-internal/issues/2534. It basically implements session pooling with fixed low watermark of 1.