### PR TITLE
Allow lampshade listeners to send immediate acks as soon as a connect…

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -95,12 +95,12 @@ func NewDialer(opts *DialerOpts) Dialer {
 		idleInterval:          opts.IdleInterval,
 		pingInterval:          opts.PingInterval,
 		redialSessionInterval: opts.RedialSessionInterval,
-		pool:                  opts.Pool,
-		cipherCode:            opts.Cipher,
-		serverPublicKey:       opts.ServerPublicKey,
-		liveSessions:          liveSessions,
-		numLive:               1, // the nullSession
-		emaRTT:                ema.NewDuration(0, 0.5),
+		pool:            opts.Pool,
+		cipherCode:      opts.Cipher,
+		serverPublicKey: opts.ServerPublicKey,
+		liveSessions:    liveSessions,
+		numLive:         1, // the nullSession
+		emaRTT:          ema.NewDuration(0, 0.5),
 	}
 }
 
@@ -224,7 +224,7 @@ func (d *dialer) startSession(dial DialFN) (*session, error) {
 		return nil, fmt.Errorf("Unable to generate client init message: %v", err)
 	}
 
-	return startSession(conn, d.windowSize, d.maxPadding, d.pingInterval, cs, clientInitMsg, d.pool, d.emaRTT, nil, nil)
+	return startSession(conn, d.windowSize, d.maxPadding, false, d.pingInterval, cs, clientInitMsg, d.pool, d.emaRTT, nil, nil)
 }
 
 type boundDialer struct {

--- a/example_test.go
+++ b/example_test.go
@@ -33,7 +33,7 @@ func ExampleWrapListener() {
 		return
 	}
 
-	ll := WrapListener(l, NewBufferPool(100), pk.RSA())
+	ll := WrapListener(l, NewBufferPool(100), pk.RSA(), true)
 	for {
 		conn, err := ll.Accept()
 		if err != nil {

--- a/lampshade_test.go
+++ b/lampshade_test.go
@@ -441,7 +441,7 @@ func echoServerAndDialerWithIdleInterval(maxStreamsPerConn uint16, amplification
 	}
 
 	pool := NewBufferPool(100)
-	l := WrapListener(wrapped, pool, pk.RSA())
+	l := WrapListener(wrapped, pool, pk.RSA(), false)
 
 	var wg sync.WaitGroup
 	go func() {
@@ -542,7 +542,7 @@ func TestConcurrency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to listen: %v", err)
 	}
-	lst := WrapListener(_lst, pool, pk.RSA())
+	lst := WrapListener(_lst, pool, pk.RSA(), true)
 
 	go func() {
 		for {
@@ -642,7 +642,7 @@ func doBenchmarkThroughputLampshade(b *testing.B, cipherCode Cipher) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	lst := WrapListener(_lst, NewBufferPool(100), pk.RSA())
+	lst := WrapListener(_lst, NewBufferPool(100), pk.RSA(), true)
 
 	conn, err := NewDialer(&DialerOpts{
 		WindowSize:      25,

--- a/receive_buffer.go
+++ b/receive_buffer.go
@@ -145,7 +145,11 @@ func (buf *receiveBuffer) sendACK() {
 		// Don't bother acking
 		return
 	}
-	buf.ack.Write(ackWithFrames(buf.defaultHeader, int32(buf.unacked)))
+	buf.doSendACK(buf.unacked)
+}
+
+func (buf *receiveBuffer) doSendACK(unacked int) {
+	buf.ack.Write(ackWithFrames(buf.defaultHeader, int32(unacked)))
 }
 
 func (buf *receiveBuffer) onFrame(frame []byte) {


### PR DESCRIPTION
…ion is opened

This attempts to address a potential detection vulnerability in that the timing of the first response packet on a lampshade connection can be slow because we're usually waiting for a connection to the origin server to proceed before we send anything to the client. This PR enables an option that causes an ACK to be sent immediately for the first frame received on a new connection. This works with existing clients as they already know how to handle ACKs and it is in fact a real ACK, just earlier than we'd usually send it.

For getlantern/lantern-internal#1926