### PR TITLE
force padding for the first write to a session

### DIFF
--- a/session.go
+++ b/session.go
@@ -127,11 +127,11 @@ func startSession(conn net.Conn, windowSize int, maxPadding int, ackOnFirst bool
 		return nil, err
 	}
 	atomic.AddInt64(&openSessions, 1)
-	ops.Go(s.sendLoop)
-	ops.Go(s.recvLoop)
 	if clientInitMsg != nil {
 		s.sendClientInitMsg(clientInitMsg)
 	}
+	ops.Go(s.sendLoop)
+	ops.Go(s.recvLoop)
 	return s, nil
 }
 


### PR DESCRIPTION
It's for the finding at https://github.com/getlantern/lantern-internal/issues/2619#issuecomment-464658108 that the first packet usually has no padding because `coalesced` is 2. This simply force padding if the init message is contained.