### PR TITLE
stop writeTimer before reset it

### DIFF
--- a/sendbuffer.go
+++ b/sendbuffer.go
@@ -66,6 +66,9 @@ func (buf *sendBuffer) sendLoop(w io.Writer) {
 		buf.closing = true
 		close(buf.in)
 		buf.muClosing.Unlock()
+		if !closeTimer.Stop() {
+			<-closeTimer.C
+		}
 		closeTimer.Reset(closeTimeout)
 	}
 

--- a/sendbuffer.go
+++ b/sendbuffer.go
@@ -127,6 +127,9 @@ func (buf *sendBuffer) doSend(b []byte, writeDeadline time.Time) (int, error) {
 	if writeDeadline.Before(now) {
 		return 0, ErrTimeout
 	}
+	if !buf.writeTimer.Stop() {
+		<-buf.writeTimer.C
+	}
 	buf.writeTimer.Reset(writeDeadline.Sub(now))
 	select {
 	case buf.in <- b:


### PR DESCRIPTION
Fix https://github.com/getlantern/lantern-internal/issues/2722. Verified that `ErrTimeout` was no longer triggered unexpectedly.

See https://godoc.org/time#Timer.Reset for details.