### PR TITLE
Synchronize access to sender.lastPing

### DIFF
--- a/session.go
+++ b/session.go
@@ -440,11 +440,13 @@ func (snd *sender) send(frame []byte) (open bool) {
 	open = snd.coalesceAdditionalFrames()
 
 	if snd.pingInterval > 0 {
+		snd.mx.Lock()
 		now := time.Now()
 		if now.Sub(snd.lastPing) > snd.pingInterval {
 			snd.bufferFrame(ping())
 			snd.lastPing = now
 		}
+		snd.mx.Unlock()
 	}
 
 	if log.IsTraceEnabled() {


### PR DESCRIPTION
https://github.com/getlantern/lantern-internal/issues/2950

Since the only references to lastPing are in the send method, it looks like we just need to synchronize access to the variable.