### PR TITLE
Tweaked active probing resistance based on recent recommendations

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -33,7 +33,9 @@ func ExampleWrapListener() {
 		return
 	}
 
-	ll := WrapListener(l, NewBufferPool(100), pk.RSA(), true)
+	ll := WrapListener(l, NewBufferPool(100), pk.RSA(), &ListenerOpts{
+		AckOnFirst: true,
+	})
 	for {
 		conn, err := ll.Accept()
 		if err != nil {


### PR DESCRIPTION
For getlantern/lantern-internal#3265

A lot of the code is just refactoring the listener constructors. The main changes are:

1. Make the InitMsgTimeout configurable and default to forever

2. If we failed to read the full init message, try consuming anyway and close when that fails. Most likely that will fail immediately because the only case I can think of where consuming the init message would fail is either that we've hit the deadline or EOF, but I don't think it hurts to try. Also, this no longer sleeps till the deadline before closing since by default, that would sleep forever now :)